### PR TITLE
JNG-4356 Unmapped transfer throws validation error to mapped transfer mandatory attributes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <spring-boot.version>2.7.3</spring-boot.version>
 
 
-   		<judo-runtime-core-version>1.0.6.20230912_043037_74721cbc_develop</judo-runtime-core-version>
+   		<judo-runtime-core-version>1.0.6.20230913_082338_96096e3d_feature_JNG_4356_Unmapped_transfer_throws_validation_error_to_mapped_transfer_mandatory_attributes</judo-runtime-core-version>
         <judo-psm-generator-sdk-core-version>1.0.0.20230912_041701_9f49da18_develop</judo-psm-generator-sdk-core-version>
 
         <!--suppress UnresolvedMavenProperty -->

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
         <spring-boot.version>2.7.3</spring-boot.version>
 
-   		<judo-runtime-core-version>1.0.6.20230908_041501_71f3fbb9_develop</judo-runtime-core-version>
+   		<judo-runtime-core-version>1.0.6.20230911_122943_c9e69af6_feature_JNG_4356_Unmapped_transfer_throws_validation_error_to_mapped_transfer_mandatory_attributes</judo-runtime-core-version>
         <judo-psm-generator-sdk-core-version>1.0.0.20230908_041138_521e5276_develop</judo-psm-generator-sdk-core-version>
 
         <!--suppress UnresolvedMavenProperty -->

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
         <spring-boot.version>2.7.3</spring-boot.version>
 
-   		<judo-runtime-core-version>1.0.6.20230913_082338_96096e3d_feature_JNG_4356_Unmapped_transfer_throws_validation_error_to_mapped_transfer_mandatory_attributes</judo-runtime-core-version>
+   		<judo-runtime-core-version>1.0.6.20230918_101554_91de931c_feature_JNG_4356_Unmapped_transfer_throws_validation_error_to_mapped_transfer_mandatory_attributes</judo-runtime-core-version>
         <judo-psm-generator-sdk-core-version>1.0.0.20230914_120625_a6090a2b_develop</judo-psm-generator-sdk-core-version>
 
         <!--suppress UnresolvedMavenProperty -->

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <spring-boot.version>2.7.3</spring-boot.version>
 
 
-   		<judo-runtime-core-version>1.0.6.20230911_122943_c9e69af6_feature_JNG_4356_Unmapped_transfer_throws_validation_error_to_mapped_transfer_mandatory_attributes</judo-runtime-core-version>
+   		<judo-runtime-core-version>1.0.6.20230912_043037_74721cbc_develop</judo-runtime-core-version>
         <judo-psm-generator-sdk-core-version>1.0.0.20230912_041701_9f49da18_develop</judo-psm-generator-sdk-core-version>
 
         <!--suppress UnresolvedMavenProperty -->


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-4356" title="JNG-4356" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-4356</a>  Aggragated mapped transfer object from unmapped transfer object with mandatory parameters throws validation error on operation call
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

JNG-4356 Unmapped transfer throws validation error to mapped transfer mandatory attributes