### PR TITLE
JNG-5089 The payload not contains the recursive single relation on the sublevels

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
         <spring-boot.version>2.7.3</spring-boot.version>
 
-   		<judo-runtime-core-version>1.0.6.20230922_132937_59d2c09b_feature_JNG_5089_The_payload_not_contains_the_recursive_single_relation_on_the_sublevels</judo-runtime-core-version>
+   		<judo-runtime-core-version>1.0.6.20230925_081834_9c618125_feature_JNG_5089_The_payload_not_contains_the_recursive_single_relation_on_the_sublevels</judo-runtime-core-version>
         <judo-psm-generator-sdk-core-version>1.0.0.20230923_041745_dfc4ca09_develop</judo-psm-generator-sdk-core-version>
 
         <!--suppress UnresolvedMavenProperty -->

--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,8 @@
 
         <spring-boot.version>2.7.3</spring-boot.version>
 
-   		<judo-runtime-core-version>1.0.6.20230921_132957_6a56e8b6_develop</judo-runtime-core-version>
-        <judo-psm-generator-sdk-core-version>1.0.0.20230921_085028_48c23a0e_develop</judo-psm-generator-sdk-core-version>
+   		<judo-runtime-core-version>1.0.6.20230922_132937_59d2c09b_feature_JNG_5089_The_payload_not_contains_the_recursive_single_relation_on_the_sublevels</judo-runtime-core-version>
+        <judo-psm-generator-sdk-core-version>1.0.0.20230914_120625_a6090a2b_develop</judo-psm-generator-sdk-core-version>
 
         <!--suppress UnresolvedMavenProperty -->
         <logback-test-config>${maven.multiModuleProjectDirectory}/logback-test.xml</logback-test-config>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5089" title="JNG-5089" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-5089</a>  In the case of recursive composition, if an entity or a TO has both single and collection composite fields, the value of the single field will be null but should be Optional.empty()
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

JNG-5089 The payload not contains the recursive single relation on the sublevels